### PR TITLE
fix: Support hyphen in interface names

### DIFF
--- a/src/ifconfig.interfaces.js
+++ b/src/ifconfig.interfaces.js
@@ -130,7 +130,7 @@ function getInterfaceName(line) {
   } else {
 
     //  Other platforms
-    nicName = /(^[a-z,A-Z,0-9]+)/.exec(line)
+    nicName = /(^[a-z,A-Z,0-9\-]+)/.exec(line)
     return nicName[1]
   }
 }


### PR DESCRIPTION
My device has a network interface device called `br-c200e6ddde1c`. network-config is unable to parse its name because of the `-`.  This breaks fsbot at `ip addr dev show ${device}`, device not found.